### PR TITLE
videos within div with class videoWrapper

### DIFF
--- a/src/js/bs3/module/VideoDialog.js
+++ b/src/js/bs3/module/VideoDialog.js
@@ -126,6 +126,7 @@ define([
         return false;
       }
 
+      $video.addClass('note-video-clip');
       var $embed = $('<div>').addClass('videoWrapper');
       $video.appendTo($embed);
 

--- a/src/js/bs3/module/VideoDialog.js
+++ b/src/js/bs3/module/VideoDialog.js
@@ -126,9 +126,10 @@ define([
         return false;
       }
 
-      $video.addClass('note-video-clip');
+      var $embed = $('<div>').addClass('videoWrapper');
+      $video.appendTo($embed);
 
-      return $video[0];
+      return $embed[0];
     };
 
     this.show = function () {


### PR DESCRIPTION
#### What does this PR do?

Adds a wrapping div to iframes of class videoWrapper. This allows external CSS to affect it however desired.
In particular I'm using this for responsive youtube videos.

#### What are the relevant tickets?
https://github.com/summernote/summernote/issues/409